### PR TITLE
Improve multi cpu sampling

### DIFF
--- a/Ubuntu/blocks.sh
+++ b/Ubuntu/blocks.sh
@@ -15,11 +15,13 @@ _CPUS_ () {
 
     [ -z "$1" ] && icon="" || icon="$1"
 
-    cpus_usage=$(mpstat -P ALL \
+    cpus_usage=$(mpstat -P ALL 1 1 \
+	| grep "^Average" \
 	| cut -d " " -f3- \
 	| column -t \
-	| awk '/^[0-9]/{print $2"%"}' \
+	| awk '/^[0-9]/{printf "%.2f% ", 100-$11"%"}' \
 	| tr "\n" " ");
+
     echo "$icon $cpus_usage"
 }
 


### PR DESCRIPTION
Calculates multi cpu usage by sampling one mpstat interval. Substracts idle usage from 100 percent. That results in better cpu statistics and is similar to the i3blocks default cpu_usage approach.